### PR TITLE
Use two ASCII upper case characters for Checksum field

### DIFF
--- a/src/nmea-sender/NmeaTelegram.cpp
+++ b/src/nmea-sender/NmeaTelegram.cpp
@@ -45,7 +45,7 @@ std::string NmeaTelegram::encode() const {
 
     nmeaMessage.append("*");
     std::stringstream stream;
-    stream << std::hex << checksum;
+    stream << std::setfill('0') << std::setw(2) << std::hex << std::uppercase << checksum;
     nmeaMessage.append(stream.str());
     nmeaMessage.append("\r\n");
 


### PR DESCRIPTION
According to IEC 61162-2, the checksum field should be converted to two upper case ASCII characters, meaning that we need to use leading zero and upper case.